### PR TITLE
Adding missing package.json, which is required for Cordova >= 7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "cordova-plugin-proguard",
+  "version": "1.0.0",
+  "description": "Activates Proguard and minification for debug and release builds",
+  "cordova": {
+    "id": "com.eightz.mobile.cordova.plugin.android.referrer",
+    "platforms": [
+      "android"
+    ]
+  },
+  "keywords": [
+    "android",
+    "cordova",
+    "proguard"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Activates Proguard and minification for debug and release builds",
   "cordova": {
-    "id": "com.eightz.mobile.cordova.plugin.android.referrer",
+    "id": "cordova-plugin-proguard",
     "platforms": [
       "android"
     ]


### PR DESCRIPTION
Starting with Cordova 7.0, plugins are required to include package.json

More info: https://cordova.apache.org/news/2017/05/04/cordova-7.html